### PR TITLE
feat: add is_first/is_last properties + expose buffers

### DIFF
--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -197,6 +197,8 @@ Buffer.new = function(b)
   return {
     _valid_index = order[b.bufnr] or -1,
     index = -1,
+    is_last = false,
+    is_first = false,
     number = b.bufnr,
     type = opts.buftype,
     is_focused = (b.bufnr == fn.bufnr("%")),
@@ -339,6 +341,8 @@ local get_visible_buffers = function()
 
   for i, buffer in ipairs(_G.cokeline.visible_buffers) do
     buffer.index = i
+    buffer.is_first = i == 1
+    buffer.is_last = i == #_G.cokeline.visible_buffers
   end
 
   return _G.cokeline.visible_buffers

--- a/lua/cokeline/components.lua
+++ b/lua/cokeline/components.lua
@@ -57,7 +57,7 @@ end
 Component.render = function(self, buffer)
   local evaluate = function(field)
     return (type(field) == "string" and field)
-      or (type(field) == "function" and field(buffer))
+      or (type(field) == "function" and field(buffer, _G.cokeline.valid_buffers))
   end
 
   local component = vim.deepcopy(self)


### PR DESCRIPTION
Adds `is_first` & `is_last` properties onto the `buffer` parameter. Useful for knowing if a tab is the first or last in the set of buffers.

Also exposes all the buffers as an argument, e.g.

```lua
{
  text: function(buffer, buffers) 
    if(buffer.is_first) return "first"
    if(buffer.is_last) return "last"
    return buffer.index .. "/" .. #buffers
  end
}
```

I've been using it in my config for a bit now https://gitlab.com/cxss/dotfiles/-/blob/main/nvim/lua/core/bufferline.lua#L52