### PR TITLE
fix(mapping): handle gracefully keyboard interrupt on buffer pick.

### DIFF
--- a/lua/cokeline/mappings.lua
+++ b/lua/cokeline/mappings.lua
@@ -69,7 +69,11 @@ local pick = function(goal)
   cmd("redrawtabline")
   is_picking[goal] = false
 
-  local letter = fn.nr2char(fn.getchar())
+  local valid_char, char = pcall(fn.getchar)
+  -- bail out on keyboard interrupt
+  if not valid_char then char = 0 end
+
+  local letter = fn.nr2char(char)
   local target_buffer = filter(function(buffer)
     return buffer.pick_letter == letter
   end, _G.cokeline.visible_buffers)[1]


### PR DESCRIPTION
When the picker mode is enabled (in focus or close mode), hitting `<C-c>` throw E5108: Error executing lua: Keyboard interrupt

This changes allow to handle `<C-c>` as if `<Esc>` was typed.