### PR TITLE
feat: custom components on rhs of tabline

### DIFF
--- a/lua/cokeline/builtin.lua
+++ b/lua/cokeline/builtin.lua
@@ -3,8 +3,9 @@ local M = {}
 M.time = function()
   local hour = os.date("%I"):gsub("0(%d)", "%1")
   local minute = os.date("%M")
+  local ampm = os.date("%p")
 
-  return hour .. ":" .. minute
+  return string.format("%s:%s %s", hour, minute, ampm)
 end
 
 return M

--- a/lua/cokeline/components.lua
+++ b/lua/cokeline/components.lua
@@ -52,18 +52,18 @@ end
 
 -- Renders a component for a specific buffer.
 ---@param self   Component
----@param buffer Buffer
+---@param ctx Buffer | table
 ---@return Component
-Component.render = function(self, buffer)
+Component.render = function(self, ctx)
   local evaluate = function(field)
     return (type(field) == "string" and field)
-      or (type(field) == "function" and field(buffer))
+      or (type(field) == "function" and field(ctx))
   end
 
   local component = vim.deepcopy(self)
   component.text = evaluate(self.text)
   component.width = fn.strwidth(component.text)
-  component.bufnr = buffer.number
+  component.bufnr = ctx.number
 
   -- `evaluate(self.hl.*)` might return `nil`, in that case we fallback to the
   -- default highlight first and to NONE if that's `nil` too.
@@ -78,7 +78,7 @@ Component.render = function(self, buffer)
     or "NONE"
 
   component.hlgroup = Hlgroup.new(
-    ("Cokeline_%s_%s"):format(buffer.number, self.index),
+    ("Cokeline_%s_%s"):format(ctx.number, self.index),
     style,
     fg,
     bg

--- a/lua/cokeline/config.lua
+++ b/lua/cokeline/config.lua
@@ -44,6 +44,12 @@ local defaults = {
     style = "NONE",
   },
 
+  ---@type { components: Component[], context: (string|fun():string)[]}
+  rhs = {
+    components = {},
+    context = {},
+  },
+
   ---@type Component[]
   components = {
     {
@@ -121,6 +127,12 @@ local get = function(preferences)
   for i, component in ipairs(config.components) do
     insert(
       _G.cokeline.components,
+      Component.new(component, i, config.default_hl)
+    )
+  end
+  for i, component in ipairs(config.rhs.components) do
+    insert(
+      _G.cokeline.rhs.components,
       Component.new(component, i, config.default_hl)
     )
   end

--- a/lua/cokeline/init.lua
+++ b/lua/cokeline/init.lua
@@ -12,6 +12,12 @@ _G.cokeline = {
   ---@type Component[]
   components = {},
 
+  ---@type { components: Component[], context: ((fun(): string) | string)[] }
+  rhs = {
+    components = {},
+    context = {},
+  },
+
   ---@type table
   config = {},
 

--- a/lua/cokeline/rendering.lua
+++ b/lua/cokeline/rendering.lua
@@ -144,6 +144,7 @@ local render = function(visible_buffers)
 
   return components.render(sidebar_components)
     .. components.render(buffer_components)
+    .. "%#TabLine#"
 end
 
 return {

--- a/lua/cokeline/rendering.lua
+++ b/lua/cokeline/rendering.lua
@@ -81,6 +81,7 @@ end
 ---the list of visible buffers, figures out which components to display and
 ---returns their rendered version.
 ---@param visible_buffers  Buffer[]
+---@diagnostic disable-next-line: incorrect_standard_library_use
 ---@return string
 local render = function(visible_buffers)
   local sidebar_components = sidebar.get_components()

--- a/lua/cokeline/rendering.lua
+++ b/lua/cokeline/rendering.lua
@@ -1,5 +1,6 @@
 local components = require("cokeline/components")
 local sidebar = require("cokeline/sidebar")
+local rhs = require("cokeline/rhs")
 
 local insert = table.insert
 local sort = table.sort
@@ -83,7 +84,9 @@ end
 ---@return string
 local render = function(visible_buffers)
   local sidebar_components = sidebar.get_components()
-  local available_width = o.columns - components.width(sidebar_components)
+  local available_width = o.columns
+    - components.width(sidebar_components)
+    - rhs.width()
   if available_width == 0 then
     return components.render(sidebar_components)
   end
@@ -102,8 +105,13 @@ local render = function(visible_buffers)
     if current_buffer.index < #visible_buffers then
       components.shorten(current_components, available_width, "right")
     end
+    local c_width = components.width(current_components)
     return components.render(sidebar_components)
       .. components.render(current_components)
+      .. "%#TabLine#"
+      .. string.rep(" ", available_width - c_width)
+      .. rhs.render()
+      .. "%#TabLine#"
   end
 
   local left_components, left_width = to_components({
@@ -142,8 +150,13 @@ local render = function(visible_buffers)
     components.shorten(buffer_components, available_width, "right")
   end
 
+  local c_width = components.width(buffer_components)
+
   return components.render(sidebar_components)
     .. components.render(buffer_components)
+    .. "%#TabLine#"
+    .. string.rep(" ", available_width - c_width)
+    .. rhs.render()
     .. "%#TabLine#"
 end
 

--- a/lua/cokeline/rhs.lua
+++ b/lua/cokeline/rhs.lua
@@ -1,0 +1,63 @@
+local components = require("cokeline/components")
+local Component = components.Component
+
+local function get_ctx()
+  return _G.cokeline.rhs.context
+end
+
+local function get_components()
+  local rhs = {}
+  for i, c in ipairs(_G.cokeline.rhs.components) do
+    rhs[i] = c:render(get_ctx())
+  end
+  return rhs
+  -- return _G.cokeline.rhs.components
+end
+
+local function width()
+  -- local width = 0
+  -- for _, c in ipairs(get_components()) do
+  --   print(vim.inspect(c))
+  --   width = width + c:render(get_ctx())
+  -- end
+  -- return width
+  return components.width(get_components())
+end
+
+-- Takes in a list of components, returns the concatenation of their rendered
+-- strings.
+---@param components  Component[]
+---@return string
+local render_components = function(components)
+  local embed = function(component)
+    local text = component.hlgroup:embed(component.text)
+    if not vim.fn.has("tablineat") then
+      return text
+    else
+      -- local on_click = "CokelineHandleClick"
+      -- return ("%%%s@%s@%s%%X"):format(component.bufnr, on_click, text)
+      return ("%s"):format(text)
+    end
+  end
+
+  return table.concat(vim.tbl_map(function(component)
+    return embed(component)
+  end, components))
+end
+
+local function render()
+  -- update dynamic context providers
+  -- for i, ctx_provider in ipairs(RHS.ctx) do
+  --   if type(ctx_provider) == "function" then
+  --     RHS.ctx[i] = ctx_provider()
+  --   end
+  -- end
+
+  -- return components.render(get_components())
+  return render_components(get_components())
+end
+
+return {
+  render = render,
+  width = width,
+}


### PR DESCRIPTION
Draft PR for the feature I'm currently working on :) You'll be able to create custom components that aren't tied to buffers, and add them to the right-hand side of the tabline. This will be a somewhat temporary change, as I'd like to support non-buffer components anywhere, but that would require significant breaking changes and I'd rather keep things stable for now.

Note I'm rewriting all of this, the initial code in this PR is just what I did to get it working initially as an experiment.