### PR TITLE
feat(pick): release taken letters when deleting buffers

### DIFF
--- a/lua/cokeline/augroups.lua
+++ b/lua/cokeline/augroups.lua
@@ -52,11 +52,18 @@ local remember_bufnr = function(bufnr)
 end
 
 local setup = function()
-  cmd([[
-  augroup cokeline_toggle
-    autocmd VimEnter,BufAdd * lua require('cokeline/augroups').toggle()
-  augroup END
-  ]])
+  local autocmd, augroup = vim.api.nvim_create_autocmd, vim.api.nvim_create_augroup
+
+  autocmd({ 'VimEnter', 'BufAdd'}, {
+    group = augroup('cokline_toggle', { clear = true }),
+    callback = function() require('cokeline/augroups').toggle() end
+  })
+  autocmd({ 'BufDelete', 'BufWipeout'}, {
+    group = augroup('cokline_release_taken_letter', { clear = true }),
+    callback = function(args)
+      require('cokeline/buffers').release_taken_letter(args.buf)
+    end
+  })
 end
 
 return {

--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -135,6 +135,15 @@ local get_pick_letter = function(filename, bufnr)
   return "?"
 end
 
+---@param bufnr  bufnr
+---@return nil
+local function release_taken_letter(bufnr)
+  if taken_pick_letters[bufnr] then
+    valid_pick_letters = valid_pick_letters .. taken_pick_letters[bufnr]
+    taken_pick_letters[bufnr] = nil
+  end
+end
+
 ---@param path  string
 ---@param filename  string
 ---@param type  string
@@ -428,4 +437,5 @@ return {
   get_visible = get_visible_buffers,
   move_buffer = move_buffer,
   get_buffer = get_buffer,
+  release_taken_letter = release_taken_letter,
 }


### PR DESCRIPTION
When all available letters get assigned to buffers, a question mark (?)
starts to appear for each new one. The pick feature is then unusable
anymore for the upcoming buffers, even if we delete those with assigned
letters.

This PR simply release the assigned letter of a deleted buffer.
