### PR TITLE
feat: add fill_hl config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,9 @@ require('cokeline').setup({
     style = 'attr1,attr2,...' | function(buffer) -> 'attr1,attr2,...',
   },
 
+  -- The highlight group used to fill the tabline space
+  fill_hl = 'TabLineFill',
+
   -- A list of components to be rendered for each buffer. Check out the section
   -- below explaining what this value can be set to.
   -- default: see `/lua/cokeline/defaults.lua`

--- a/doc/cokeline.txt
+++ b/doc/cokeline.txt
@@ -112,6 +112,8 @@ The valid keys are:
       style = 'attr1,attr2,...' | function(buffer) -> 'attr1,attr2,...',
     },
 
+    -- The highlight group used to fill the tabline space
+    fill_hl = 'TabLineFill',
 
     -- A list of components to be rendered for each buffer (see
     -- |cokeline-components|).

--- a/lua/cokeline/config.lua
+++ b/lua/cokeline/config.lua
@@ -44,6 +44,8 @@ local defaults = {
     style = "NONE",
   },
 
+  fill_hl = 'TabLineFill',
+
   ---@type Component[]
   components = {
     {

--- a/lua/cokeline/init.lua
+++ b/lua/cokeline/init.lua
@@ -57,7 +57,7 @@ _G.cokeline.tabline = function()
     opt.showtabline = 0
     return
   end
-  return rendering.render(visible_buffers)
+  return rendering.render(visible_buffers, _G.cokeline.config.fill_hl)
 end
 
 return {

--- a/lua/cokeline/rendering.lua
+++ b/lua/cokeline/rendering.lua
@@ -89,7 +89,7 @@ end
 ---the list of visible buffers, figures out which components to display, and
 ---returns a list of pre-render components
 ---@param visible_buffers  Buffer[]
----@return string
+---@return table|string
 local prepare = function(visible_buffers)
   local sidebar_components = sidebar.get_components()
   local rhs_components = rhs.get_components()
@@ -178,15 +178,16 @@ end
 ---the list of visible buffers, figures out which components to display and
 ---returns their rendered version.
 ---@param visible_buffers  Buffer[]
+---@param fill_hl string
 ---@return string
-local render = function(visible_buffers)
+local render = function(visible_buffers, fill_hl)
   local cx = prepare(visible_buffers)
   return components.render(cx.sidebar)
     .. components.render(cx.buffers)
-    .. "%#TabLine#"
+    .. "%#" .. fill_hl .. "#"
     .. string.rep(" ", cx.gap)
     .. components.render(cx.rhs)
-    .. "%#TabLine#"
+    .. "%#" .. fill_hl .. "#"
 end
 
 return {


### PR DESCRIPTION
Make the colors of the filler space configurable.

From `:h syntax.txt`, I think we should use `TabLineFill` instead of `TabLine`. This might break people's tabline color, so I make the highlight group a config option and naively pass it to the `render()` function.
```help
							*hl-TabLine*
TabLine		Tab pages line, not active tab page label.
							*hl-TabLineFill*
TabLineFill	Tab pages line, where there are no labels.

```