### PR TITLE
fix: allow multibyte characters on buffer picker

### DIFF
--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -113,7 +113,7 @@ local get_pick_letter = function(filename, bufnr)
   -- If the config option pick.use_filename is true, and the initial letter
   -- of the filename is valid and it hasn't already been assigned return that.
   if _G.cokeline.config.pick.use_filename then
-    local init_letter = filename:sub(1, 1)
+    local init_letter = vim.fn.strcharpart(filename, 0, 1)
     if valid_pick_letters:find(init_letter, nil, true) then
       valid_pick_letters = valid_pick_letters:gsub(init_letter, "")
       taken_pick_letters[bufnr] = init_letter
@@ -123,8 +123,8 @@ local get_pick_letter = function(filename, bufnr)
 
   -- Return the first valid letter if there is one.
   if #valid_pick_letters > 0 then
-    local first_valid = valid_pick_letters:sub(1, 1)
-    valid_pick_letters = valid_pick_letters:sub(2)
+    local first_valid = vim.fn.strcharpart(valid_pick_letters, 0, 1)
+    valid_pick_letters = vim.fn.strcharpart(valid_pick_letters, 1, #valid_pick_letters - 1)
     taken_pick_letters[bufnr] = first_valid
     return first_valid
   end


### PR DESCRIPTION
Hey, thanks for such a cool plugin. In the past I struggled with tabline plugins and setting the paddings and names like I wanted, and this plugin just let us do everything we want it, I really appreciate it :pray: 

But I have found that the buffer_picker would not work very well when the filename starts with a mulibyte character, when we're using the filename to decide the picker character, or if we set multibyte characters in the `letters` option in the setup. And by multibyte character I mean things like `ç`, `ã`, `é` etc.

My keyboard layout has special characters, so I wanted to use them in the "letters" option, but then it would show some weird characters, like this:

![image](https://github.com/willothy/nvim-cokeline/assets/60318892/9dbdf91f-bad0-4a44-8f07-cf0aea5f0da7)

Here my first letter should be `ç`, but it is shown as this weird `<c3>` thing on first buffer and `<a7>` on the second, which are the first and second byte of the multibyte character `ç`. And even if I do press `ç`, it takes me nowhere. I suspected this would be caused by lua not treating strings the way I'd usually expect. I very recently had an issue setting cokeline up, as you can see in this reddit post: https://www.reddit.com/r/neovim/comments/14kdw8v/how_to_get_the_first_character_of_a_string_when/

So I peeked the code really quick and found some `string.sub` usage, which is exactly what breaks it. I changed it for some `vim.fn.strcharpart`, which takes an index (0 based) and a length and gets the substring, but this index is considering characters, and not bytes, unlike lua's `string.sub` function.

Maybe I should have opened an issue, but since I got what apparently could be the fix, I opened a pull request directly. Sorry if that was not cool! ):

Anyways, what is your opinion on this?