### PR TITLE
feat: support for passing highlight group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,9 @@ Every component passed to the `components` list has to be a table of the form:
   bg = '#rrggbb' | function(buffer) -> '#rrggbb',
   style = 'attr1,attr2,...' | function(buffer) -> 'attr1,attr2,...',
 
+  -- Or, alternatively, the name of the highlight group
+  highlight = 'string' | function(buffer) -> string | nil,
+
   -- If `true` the buffer will be deleted when this component is
   -- left-clicked (usually used to implement close buttons, overrides `on_click`).
   -- deprecated, it is recommended to use the Buffer:delete() method in an on_click event

--- a/doc/cokeline.txt
+++ b/doc/cokeline.txt
@@ -258,6 +258,9 @@ Every component passed to the `components` list has to be a table of the form:
     bg = '#rrggbb' | function(buffer) -> '#rrggbb' | nil,
     style = 'string' | nil,
 
+    -- Or, alternatively, the name of the highlight group
+    highlight = 'string' | function(buffer) -> string | nil,
+
     -- If `true` the buffer will be deleted when this component is
     -- left-clicked (useful to implement close buttons).
     delete_buffer_on_left_click = boolean,

--- a/lua/cokeline/components.lua
+++ b/lua/cokeline/components.lua
@@ -14,7 +14,7 @@ local map = vim.tbl_map
 ---@field style  string|fun(buffer:Buffer): string
 ---@field fg  string|fun(buffer:Buffer): string
 ---@field bg  string|fun(buffer:Buffer): string
----@field hl_group  string|fun(buffer:Buffer): string
+---@field highlight  string|fun(buffer:Buffer): string
 ---@field on_click ClickHandler | nil
 ---@field on_mouse_enter MouseEnterHandler | nil
 ---@field on_mouse_leave MouseLeaveHandler | nil
@@ -39,7 +39,7 @@ Component.new = function(c, i, default_hl)
     fg = c.fg or default_hl.fg or "NONE",
     bg = c.bg or default_hl.bg or "NONE",
     style = c.style or default_hl.style or "NONE",
-    hl_group = c.hl_group,
+    highlight = c.highlight,
     delete_buffer_on_left_click = c.delete_buffer_on_left_click or false,
     on_click = c.on_click,
     on_mouse_enter = c.on_mouse_enter,
@@ -90,8 +90,8 @@ Component.render = function(self, context)
     or evaluate(_G.cokeline.config.default_hl.bg)
     or "NONE"
 
-  if component.hl_group then
-    component.hlgroup = Hlgroup.new_existing(evaluate(component.hl_group))
+  if component.highlight then
+    component.hlgroup = Hlgroup.new_existing(evaluate(component.highlight))
   else
     component.hlgroup = Hlgroup.new(
       ("Cokeline_%s_%s"):format(component.bufnr or context.kind, self.index),

--- a/lua/cokeline/components.lua
+++ b/lua/cokeline/components.lua
@@ -14,6 +14,7 @@ local map = vim.tbl_map
 ---@field style  string|fun(buffer:Buffer): string
 ---@field fg  string|fun(buffer:Buffer): string
 ---@field bg  string|fun(buffer:Buffer): string
+---@field hl_group  string|fun(buffer:Buffer): string
 ---@field on_click ClickHandler | nil
 ---@field on_mouse_enter MouseEnterHandler | nil
 ---@field on_mouse_leave MouseLeaveHandler | nil
@@ -38,6 +39,7 @@ Component.new = function(c, i, default_hl)
     fg = c.fg or default_hl.fg or "NONE",
     bg = c.bg or default_hl.bg or "NONE",
     style = c.style or default_hl.style or "NONE",
+    hl_group = c.hl_group,
     delete_buffer_on_left_click = c.delete_buffer_on_left_click or false,
     on_click = c.on_click,
     on_mouse_enter = c.on_mouse_enter,
@@ -88,12 +90,16 @@ Component.render = function(self, context)
     or evaluate(_G.cokeline.config.default_hl.bg)
     or "NONE"
 
-  component.hlgroup = Hlgroup.new(
-    ("Cokeline_%s_%s"):format(component.bufnr or context.kind, self.index),
-    style,
-    fg,
-    bg
-  )
+  if component.hl_group then
+    component.hlgroup = Hlgroup.new_existing(evaluate(component.hl_group))
+  else
+    component.hlgroup = Hlgroup.new(
+      ("Cokeline_%s_%s"):format(component.bufnr or context.kind, self.index),
+      style,
+      fg,
+      bg
+    )
+  end
 
   return component
 end

--- a/lua/cokeline/hlgroups.lua
+++ b/lua/cokeline/hlgroups.lua
@@ -31,6 +31,17 @@ Hlgroup.new = function(name, gui, guifg, guibg)
   return hlgroup
 end
 
+---Using already existing highlight group, returns a new `Hlgroup` table.
+---@param name  string
+---@return Hlgroup
+Hlgroup.new_existing = function(name)
+  local hlgroup = {
+    name = name,
+  }
+  setmetatable(hlgroup, Hlgroup)
+  return hlgroup
+end
+
 ---Embeds some text in a highlight group.
 ---@param self Hlgroup
 ---@param text string


### PR DESCRIPTION
Hello,

I added an option to pass highlight group names to components for better color scheme support. For example:
```lua
{
    text = function(buffer)
        return buffer.unique_prefix
    end,
    highlight = 'Comment'
},
```

Similarly to other options, `highlight` accepts both `string` with the highlight group name and `function(buffer) -> string`.

When `highlight` is passed, `fg`, `bg`, and `style` parameters are ignored.