### PR TITLE
feat: buffer history ringbuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,13 +388,19 @@ Each component has access to an is_hovered property, and can be given custom `on
 
 ![hover-events-2](https://github.com/willothy/nvim-cokeline/assets/38540736/3b319c79-0bff-41dd-9a08-36fd627b3d08)
 
-### Buffer re-ordering
+### Buffer re-ordering (including mouse-drag reordering)
 
 ![reordering](https://user-images.githubusercontent.com/38540736/226447818-bdf63d70-e153-4353-992d-d317a5764c09.gif)
 
 ### Close icons
 
 ![close-icons](https://user-images.githubusercontent.com/38540736/226447802-29b2919e-dd20-4789-8d6a-250d6d453c64.gif)
+
+### Buffer history tracking
+
+```lua
+require("cokeline.history"):last():focus()
+```
 
 ## :mountain: Plans and Ideas
 
@@ -519,6 +525,12 @@ require('cokeline').setup({
     -- Disables mouse mappings
     -- default: `false`.
     disable_mouse = true | false,
+  },
+
+  -- Maintains a history of focused buffers using a ringbuffer
+  history = {
+    enabled = true | false (default: true)
+    size = int (default: 2)
   },
 
   rendering = {
@@ -809,6 +821,59 @@ the filename has to be shortened you'll still be able to see its extension,
 like in the following example (where it's set to `'left'`):
 
 ![buffer-truncation](https://user-images.githubusercontent.com/38540736/226447798-6aee2e0f-f957-42ab-96dd-3618e78ba4ba.png)
+
+#### What about `history`?
+
+The History keeps track of the buffers you access using a ringbuffer, and provides
+an API for accessing Buffer objects from the history.
+
+You can access the history using `require("cokeline.history")`, or through the global `_G.cokeline.history`.
+
+The `History` object provides these methods:
+
+```lua
+---Adds a Buffer object to the history
+function History:push(bufnr: int)
+end
+
+---Removes and returns the oldest Buffer object in the history
+function History:pop(): Buffer | nil
+end
+
+---Returns a list of Buffer objects in the history,
+---ordered from oldest to newest
+function History:list(): Buffer[]
+end
+
+---Returns an iterator of Buffer objects in the history,
+---ordered from oldest to newest
+function History:iter(): fun(): Buffer | nil
+end
+
+---Get a Buffer object by history index
+function History:get(idx: int): Buffer | nil
+end
+
+---Get a Buffer object representing the last-accessed buffer (before the current one)
+function History:last(): Buffer | nil
+end
+
+---Returns true if the history is empty
+function History:is_empty(): boolean
+end
+
+---Returns the maximum number of buffers that can be stored in the history
+function History:capacity(): int
+end
+
+---Returns true if the history contains the given buffer
+function History:contains(bufnr: int): bool
+end
+
+---Returns the number of buffers in the history
+function History:len(): int
+end
+```
 
 ## :musical_keyboard: Mappings
 

--- a/doc/cokeline.txt
+++ b/doc/cokeline.txt
@@ -88,6 +88,12 @@ The valid keys are:
       disable_mouse = true | false,
     },
 
+    -- Maintains a history of focused buffers using a ringbuffer
+    history = {
+      enabled = true | false (default: true)
+      size = int (default: 2)
+    },
+
     rendering = {
       -- The maximum number of characters a rendered buffer is allowed to take
       -- up. The buffer will be truncated if its width is bigger than this

--- a/lua/cokeline/augroups.lua
+++ b/lua/cokeline/augroups.lua
@@ -52,18 +52,30 @@ local remember_bufnr = function(bufnr)
 end
 
 local setup = function()
-  local autocmd, augroup = vim.api.nvim_create_autocmd, vim.api.nvim_create_augroup
+  local autocmd, augroup =
+    vim.api.nvim_create_autocmd, vim.api.nvim_create_augroup
 
-  autocmd({ 'VimEnter', 'BufAdd'}, {
-    group = augroup('cokline_toggle', { clear = true }),
-    callback = function() require('cokeline/augroups').toggle() end
+  autocmd({ "VimEnter", "BufAdd" }, {
+    group = augroup("cokeline_toggle", { clear = true }),
+    callback = function()
+      require("cokeline/augroups").toggle()
+    end,
   })
-  autocmd({ 'BufDelete', 'BufWipeout'}, {
-    group = augroup('cokline_release_taken_letter', { clear = true }),
+  autocmd({ "BufDelete", "BufWipeout" }, {
+    group = augroup("cokeline_release_taken_letter", { clear = true }),
     callback = function(args)
-      require('cokeline/buffers').release_taken_letter(args.buf)
-    end
+      require("cokeline/buffers").release_taken_letter(args.buf)
+    end,
   })
+  if _G.cokeline.config.history.enabled and _G.cokeline.history then
+    autocmd("BufLeave", {
+      group = augroup("cokeline_buf_history", { clear = true }),
+      callback = function()
+        local buf = vim.api.nvim_get_current_buf()
+        _G.cokeline.history:push(buf)
+      end,
+    })
+  end
 end
 
 return {

--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -124,7 +124,8 @@ local get_pick_letter = function(filename, bufnr)
   -- Return the first valid letter if there is one.
   if #valid_pick_letters > 0 then
     local first_valid = vim.fn.strcharpart(valid_pick_letters, 0, 1)
-    valid_pick_letters = vim.fn.strcharpart(valid_pick_letters, 1, #valid_pick_letters - 1)
+    valid_pick_letters =
+      vim.fn.strcharpart(valid_pick_letters, 1, #valid_pick_letters - 1)
     taken_pick_letters[bufnr] = first_valid
     return first_valid
   end
@@ -143,9 +144,11 @@ local get_devicon = function(path, filename, buftype, filetype)
   local name = (buftype == "terminal") and "terminal" or filename
 
   local extn = fn.fnamemodify(path, ":e")
-  local icon, color = rq_devicons.get_icon_color(name, extn, { default = false })
+  local icon, color =
+    rq_devicons.get_icon_color(name, extn, { default = false })
   if not icon then
-    icon, color = rq_devicons.get_icon_color_by_filetype(filetype, { default = true })
+    icon, color =
+      rq_devicons.get_icon_color_by_filetype(filetype, { default = true })
   end
 
   return {
@@ -200,7 +203,8 @@ Buffer.new = function(b)
       and get_pick_letter(filename, number)
     or "?"
 
-  local devicon = has_devicons and get_devicon(path, filename, buftype, filetype)
+  local devicon = has_devicons
+      and get_devicon(path, filename, buftype, filetype)
     or { icon = "", color = "" }
 
   return setmetatable({
@@ -448,6 +452,15 @@ function M.get_buffer(bufnr)
   return vim.tbl_filter(function(buffer)
     return buffer.number == bufnr
   end, M.get_visible())[1]
+end
+
+---Wrapper around `vim.api.nvim_get_current_buf`, returns Buffer object
+---@return Buffer|nil
+function M.get_current()
+  local bufnr = vim.api.nvim_get_current_buf()
+  if bufnr then
+    return M.get_buffer(bufnr)
+  end
 end
 
 M.Buffer = Buffer

--- a/lua/cokeline/config.lua
+++ b/lua/cokeline/config.lua
@@ -23,6 +23,11 @@ local defaults = {
     disable_mouse = false,
   },
 
+  history = {
+    enabled = true,
+    size = 2,
+  },
+
   rendering = {
     max_buffer_width = 999,
     slider = sliders.center_current_buffer,

--- a/lua/cokeline/history.lua
+++ b/lua/cokeline/history.lua
@@ -1,0 +1,120 @@
+local buffers = require("cokeline.buffers")
+
+---@class Cokeline.History
+---@field len integer
+---@field cap integer
+---@field data bufnr[]
+local History = {}
+
+---Creates a new History object
+---@return Cokeline.History
+function History.setup(cap)
+  History.cap = cap
+  History.len = 0
+  History.read = 1
+  History.write = 1
+  History.data = {}
+end
+
+---Adds a Buffer object to the history
+---@param bufnr bufnr
+function History:push(bufnr)
+  self.data[self.write] = bufnr
+  self.write = (self.write % self.cap) + 1
+  if self.len < self.cap then
+    self.len = self.len + 1
+  end
+end
+
+---Removes and returns the oldest Buffer object in the history
+---@return Buffer|nil
+function History:pop()
+  if self.len == 0 then
+    return nil
+  end
+  local bufnr = self.data[self.read]
+  self.data[self.read] = nil
+  self.read = (self.read % self.cap) + 1
+  if bufnr then
+    self.len = self.len - 1
+  end
+  if bufnr then
+    return buffers.get_buffer(bufnr)
+  end
+end
+
+---Returns a list of Buffer objects in the history,
+---ordered from oldest to newest
+---@return Buffer[]
+function History:list()
+  local list = {}
+  local read = self.read
+  for _ = 1, self.len do
+    local buf = self.data[read]
+    if buf then
+      table.insert(list, buffers.get_buffer(buf))
+    end
+    read = (read % self.cap) + 1
+  end
+  return list
+end
+
+---Returns an iterator of Buffer objects in the history,
+---ordered from oldest to newest
+---@return fun():Buffer
+function History:iter()
+  local read = self.read
+  return function()
+    local buf = self.data[read]
+    if buf then
+      read = (read % self.cap) + 1
+      return buffers.get_buffer(buf)
+    end
+  end
+end
+
+---Get a Buffer object by history index
+---@param idx integer
+---@return Buffer|nil
+function History:get(idx)
+  local buf = self.data[(self.read % self.cap) + idx + 1]
+  if buf then
+    return buffers.get_buffer(buf)
+  end
+end
+
+---Get a Buffer object representing the last-accessed buffer (before the current one)
+---@return Buffer|nil
+function History:last()
+  local buf = self.data[self.write == 1 and self.len or (self.write - 1)]
+  if buf then
+    return buffers.get_buffer(buf)
+  end
+end
+
+---Returns true if the history is empty
+---@return boolean
+function History:is_empty()
+  return self.read == self.write
+end
+
+---Returns the maximum number of buffers that can be stored in the history
+---@return integer
+function History:capacity()
+  return self.cap
+end
+
+---Returns true if the history contains the given buffer
+---@param bufnr bufnr
+---@return boolean
+function History:contains(bufnr)
+  return vim.tbl_contains(self.data, bufnr)
+end
+
+---Returns the number of buffers in the history
+---@return integer
+function History:len()
+  return self.len
+end
+
+return History

--- a/lua/cokeline/init.lua
+++ b/lua/cokeline/init.lua
@@ -4,6 +4,7 @@ local config = require("cokeline/config")
 local mappings = require("cokeline/mappings")
 local rendering = require("cokeline/rendering")
 local hover = require("cokeline/hover")
+local history = require("cokeline/history")
 
 local opt = vim.opt
 
@@ -33,12 +34,19 @@ _G.cokeline = {
   ---@type table<bufnr, valid_index>
   buf_order = {},
 
+  ---@type Cokeline.History
+  history = nil,
+
   __handlers = require("cokeline/handlers"),
 }
 
 ---@param preferences table|nil
 local setup = function(preferences)
   _G.cokeline.config = config.get(preferences or {})
+  if _G.cokeline.config.history.enabled then
+    history.setup(_G.cokeline.config.history.size)
+    _G.cokeline.history = history
+  end
   augroups.setup()
   mappings.setup()
   hover.setup()


### PR DESCRIPTION
Adds a fixed-sized ringbuffer that keeps track of buffer history, and allows access to Buffer objects from anywhere. Size is configurable, and the history can be disabled if you don't want to use it.

Closes #109 