### PR TITLE
Use named color names

### DIFF
--- a/lua/cokeline/hlgroups.lua
+++ b/lua/cokeline/hlgroups.lua
@@ -16,10 +16,10 @@ Hlgroup.__index = Hlgroup
 ---@param guibg string
 ---@return Hlgroup
 Hlgroup.new = function(name, gui, guifg, guibg)
-  if guifg:sub(1, 1) ~= "#" then
+  if vim.fn.hlexists(guifg) == 1 then
     guifg = get_hex(guifg, "fg")
   end
-  if guibg:sub(1, 1) ~= "#" then
+  if vim.fn.hlexists(guibg) == 1 then
     guibg = get_hex(guibg, "bg")
   end
 


### PR DESCRIPTION
So it appears that the commit c29c2a1bd95c9145c403d81bef47667009d5041b makes the `Hlgroup.new` call get_hex on both fg and bg, but get_hex returns an empty string when we pass a name, like `red`. So we cannot set a component like this anymore:

```
{
  text = ...,
  fg = 'red',
}
```

Before it just simply passed the value as is to a `vim.cmd('highlight ...')`, so we could use color names without a problem.

I think it is nice to able to get the color of a hlgroup, which is what the mention commit does, so I think we should definitely keep that. I then started looking at the code and noticed that it looks at the first character passed to fg (or bg) and checks if it is a `#` to decide if the user passed a hlgroup name or a color.

After weird workarounds (that included hardcoding some names 😅 - not good workarounds) and some googleing around, I found out that vim has a function `hlexists`, which receives a string and returns 0 if a hlgroup with that name does not exist and 1 if it does.

So I think we could change the check to use that function instead of looking if the first character of the string is `#` or not.

What do you think?