### PR TITLE
feat: native tab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,9 @@ EOF
 
 ## :wrench: Configuration
 
+> **note**<br>
+> Check out the [wiki](https://github.com/willothy/nvim-cokeline/wiki) for more details and API documentation.
+
 All the configuration is done by changing the contents of the Lua table passed to
 the `setup` function.
 

--- a/lua/cokeline/augroups.lua
+++ b/lua/cokeline/augroups.lua
@@ -70,59 +70,61 @@ local setup = function()
       require("cokeline/buffers").release_taken_letter(args.buf)
     end,
   })
-  autocmd(
-    { "WinNew", "WinClosed", "TabNew", "TabClosed", "TermOpen", "TermClose" },
-    {
-      group = augroup("cokeline_fetch_tabs", { clear = true }),
-      callback = function(args)
-        local bt = (vim.bo[args.buf] or {}).buftype
-        if bt and bt ~= "" and bt ~= "terminal" then
-          return
-        end
-        tabs.fetch_tabs()
-      end,
-    }
-  )
-  autocmd("WinEnter", {
-    group = augroup("cokeline_update_tab_focus", { clear = true }),
-    callback = function()
-      local win = vim.api.nvim_get_current_win()
-      local tab = vim.api.nvim_win_get_tabpage(win)
-      if not _G.cokeline.tab_lookup[tab] then
-        tabs.fetch_tabs()
-        return
-      end
-      for _, w in ipairs(_G.cokeline.tab_lookup[tab].windows) do
-        if w.number == win then
-          _G.cokeline.tab_lookup[tab].focused = w
-          break
-        end
-      end
-    end,
-  })
-  autocmd("BufEnter", {
-    group = augroup("cokeline_update_tab_win_buf", { clear = true }),
-    callback = function(args)
-      local win = vim.api.nvim_get_current_win()
-      local tab = vim.api.nvim_win_get_tabpage(win)
-      if not _G.cokeline.tab_lookup[tab] then
-        tabs.fetch_tabs()
-        return
-      end
-      for _, w in ipairs(_G.cokeline.tab_lookup[tab].windows) do
-        if w.number == win then
-          w.buffer = buffers.get_buffer(args.buf)
-          break
-        end
-      end
-    end,
-  })
   if _G.cokeline.config.history.enabled and _G.cokeline.history then
     autocmd("BufLeave", {
       group = augroup("cokeline_buf_history", { clear = true }),
       callback = function(args)
         if _G.cokeline.valid_lookup[args.buf] then
           _G.cokeline.history:push(args.buf)
+        end
+      end,
+    })
+  end
+  if _G.cokeline.config.tabs then
+    autocmd(
+      { "WinNew", "WinClosed", "TabNew", "TabClosed", "TermOpen", "TermClose" },
+      {
+        group = augroup("cokeline_fetch_tabs", { clear = true }),
+        callback = function(args)
+          local bt = (vim.bo[args.buf] or {}).buftype
+          if bt and bt ~= "" and bt ~= "terminal" then
+            return
+          end
+          tabs.fetch_tabs()
+        end,
+      }
+    )
+    autocmd("WinEnter", {
+      group = augroup("cokeline_update_tab_focus", { clear = true }),
+      callback = function()
+        local win = vim.api.nvim_get_current_win()
+        local tab = vim.api.nvim_win_get_tabpage(win)
+        if not _G.cokeline.tab_lookup[tab] then
+          tabs.fetch_tabs()
+          return
+        end
+        for _, w in ipairs(_G.cokeline.tab_lookup[tab].windows) do
+          if w.number == win then
+            _G.cokeline.tab_lookup[tab].focused = w
+            break
+          end
+        end
+      end,
+    })
+    autocmd("BufEnter", {
+      group = augroup("cokeline_update_tab_win_buf", { clear = true }),
+      callback = function(args)
+        local win = vim.api.nvim_get_current_win()
+        local tab = vim.api.nvim_win_get_tabpage(win)
+        if not _G.cokeline.tab_lookup[tab] then
+          tabs.fetch_tabs()
+          return
+        end
+        for _, w in ipairs(_G.cokeline.tab_lookup[tab].windows) do
+          if w.number == win then
+            w.buffer = buffers.get_buffer(args.buf)
+            break
+          end
         end
       end,
     })

--- a/lua/cokeline/augroups.lua
+++ b/lua/cokeline/augroups.lua
@@ -103,6 +103,7 @@ local setup = function()
           tabs.fetch_tabs()
           return
         end
+        tabs.update_current(tab)
         for _, w in ipairs(_G.cokeline.tab_lookup[tab].windows) do
           if w.number == win then
             _G.cokeline.tab_lookup[tab].focused = w

--- a/lua/cokeline/config.lua
+++ b/lua/cokeline/config.lua
@@ -94,20 +94,7 @@ local defaults = {
     },
   },
 
-  tabs = {
-    placement = "left",
-    components = {
-      {
-        ---@param tabpage TabPage
-        text = function(tabpage)
-          return string.format("%s", tabpage.number)
-        end,
-        on_click = function(tabpage)
-          vim.api.nvim_set_current_tabpage(tabpage.tabnr)
-        end,
-      },
-    },
-  },
+  tabs = false,
 
   rhs = false,
 
@@ -143,6 +130,7 @@ local function update(settings, preferences, key)
         type(v) == "table"
         and not islist(v)
         and not k:find("sidebar")
+        and not k:find("tabs")
       )
           and update(settings[k], v, key_tree)
         or v

--- a/lua/cokeline/config.lua
+++ b/lua/cokeline/config.lua
@@ -94,6 +94,21 @@ local defaults = {
     },
   },
 
+  tabs = {
+    placement = "left",
+    components = {
+      {
+        ---@param tabpage TabPage
+        text = function(tabpage)
+          return string.format("%s", tabpage.number)
+        end,
+        on_click = function(tabpage)
+          vim.api.nvim_set_current_tabpage(tabpage.tabnr)
+        end,
+      },
+    },
+  },
+
   rhs = false,
 
   sidebar = false,
@@ -141,6 +156,7 @@ local get = function(preferences)
   _G.cokeline.components = {}
   _G.cokeline.rhs = {}
   _G.cokeline.sidebar = {}
+  _G.cokeline.tabs = {}
   local id = 1
   for _, component in ipairs(config.components) do
     local new_component = Component.new(component, id, config.default_hl)
@@ -166,6 +182,17 @@ local get = function(preferences)
       component.kind = "sidebar"
       local new_component = Component.new(component, id, config.default_hl)
       insert(_G.cokeline.sidebar, new_component)
+      if new_component.on_click ~= nil then
+        require("cokeline/handlers").click:register(id, new_component.on_click)
+      end
+      id = id + 1
+    end
+  end
+  if config.tabs and config.tabs.components then
+    for _, component in ipairs(config.tabs.components) do
+      component.kind = "tab"
+      local new_component = Component.new(component, id, config.default_hl)
+      insert(_G.cokeline.tabs, new_component)
       if new_component.on_click ~= nil then
         require("cokeline/handlers").click:register(id, new_component.on_click)
       end

--- a/lua/cokeline/context.lua
+++ b/lua/cokeline/context.lua
@@ -1,17 +1,40 @@
----@alias ContextKind '"buffer"' | '"tab"' | '"rhs"'
+---@alias ContextKind "buffer" | "tab" | "rhs" | "sidebar"
 
 ---@class RenderContext
 ---@field kind ContextKind
----@field provider Buffer | Tab
-local RenderContext = {
-  kind = "buffer",
-}
+---@field provider Buffer | TabPage | RhsContext | SidebarContext
+local RenderContext = {}
 
----@param kind ContextKind
----@param provider Buffer | Tab | RhsContext
----@return RenderContext
-function RenderContext:new(provider, kind)
-  return setmetatable({ provider = provider, kind = kind }, { __index = self })
+---@param tab TabPage
+function RenderContext:tab(tab)
+  return {
+    provider = tab,
+    kind = "tab",
+  }
+end
+
+---@param rhs RhsContext
+function RenderContext:rhs(rhs)
+  return {
+    provider = rhs,
+    kind = "rhs",
+  }
+end
+
+---@param buffer Buffer
+function RenderContext:buffer(buffer)
+  return {
+    provider = buffer,
+    kind = "buffer",
+  }
+end
+
+---@param sidebar SidebarContext
+function RenderContext:sidebar(sidebar)
+  return {
+    provider = sidebar,
+    kind = "sidebar",
+  }
 end
 
 return RenderContext

--- a/lua/cokeline/hover.lua
+++ b/lua/cokeline/hover.lua
@@ -44,6 +44,12 @@ function M.get_current(col)
       return component, cx.sidebar
     end
   end
+  for _, component in ipairs(cx.tabs) do
+    current_width = current_width + component.width
+    if current_width >= col then
+      return component, cx.tabs
+    end
+  end
   for _, component in ipairs(cx.buffers) do
     current_width = current_width + component.width
     if current_width >= col then

--- a/lua/cokeline/init.lua
+++ b/lua/cokeline/init.lua
@@ -10,14 +10,17 @@ local opt = vim.opt
 
 ---Global table used to manage the plugin's state.
 _G.cokeline = {
-  ---@type Component[]
+  ---@type Component<Buffer>[]
   components = {},
 
-  ---@type Component[]
+  ---@type Component<RhsContext>[]
   rhs = {},
 
-  ---@type Component[]
+  ---@type Component<SidebarContext>[]
   sidebar = {},
+
+  ---@type Component<TabPage>[]
+  tabs = {},
 
   ---@type table
   config = {},
@@ -25,16 +28,22 @@ _G.cokeline = {
   ---@type fun(): string
   tabline = nil,
 
+  ---@type TabPage[]
+  tab_cache = {},
+
+  ---@type table<tabpage, TabPage>
+  tab_lookup = {},
+
   ---@type Buffer[]
   valid_buffers = {},
 
-  ---@type table<bufnr, Buffer>
+  ---@type table<buffer, Buffer>
   valid_lookup = {},
 
   ---@type Buffer[]
   visible_buffers = {},
 
-  ---@type table<bufnr, valid_index>
+  ---@type table<buffer, valid_index>
   buf_order = {},
 
   ---@type Cokeline.History
@@ -43,7 +52,8 @@ _G.cokeline = {
   __handlers = require("cokeline/handlers"),
 }
 
----@param preferences table|nil
+--@param preferences table|nil
+---@param preferences Component<TabPage>
 local setup = function(preferences)
   _G.cokeline.config = config.get(preferences or {})
   if _G.cokeline.config.history.enabled then

--- a/lua/cokeline/rendering.lua
+++ b/lua/cokeline/rendering.lua
@@ -189,7 +189,7 @@ local prepare = function(visible_buffers)
     )
   end
   if right_width > available_width_right then
-    components.shorten(buffer_components, available_width, "right")
+    components.shorten(buffer_components, available_width - rhs_width, "right")
   end
 
   local bufs_width = components.width(buffer_components)

--- a/lua/cokeline/rhs.lua
+++ b/lua/cokeline/rhs.lua
@@ -10,7 +10,7 @@ function M.get_components()
     local is_hovered = hovered and hovered.index == c.index
     table.insert(
       rhs,
-      c:render(RenderContext:new({
+      c:render(RenderContext:rhs({
         is_hovered = is_hovered,
       }, "rhs"))
     )

--- a/lua/cokeline/sidebar.lua
+++ b/lua/cokeline/sidebar.lua
@@ -12,7 +12,7 @@ local bo = vim.bo
 local fn = vim.fn
 local o = vim.o
 
----@return Component[]
+---@return Component<SidebarContext>[]
 local get_components = function()
   if not _G.cokeline.config.sidebar then
     return {}
@@ -87,7 +87,7 @@ local get_components = function()
   local id = #_G.cokeline.components + #_G.cokeline.rhs + 1
   for _, c in ipairs(_G.cokeline.sidebar) do
     buffer.is_hovered = hover and hover.index == id
-    local component = c:render(RenderContext:new(buffer))
+    local component = c:render(RenderContext:buffer(buffer))
     buffer.is_hovered = false
     -- We need at least one component, otherwise we can't add padding to the
     -- last component if needed.

--- a/lua/cokeline/tabs.lua
+++ b/lua/cokeline/tabs.lua
@@ -1,0 +1,100 @@
+local buffers = require("cokeline.buffers")
+local Buffer = buffers.Buffer
+local components = require("cokeline/components")
+local RenderContext = require("cokeline.context")
+
+local M = {}
+
+---@class Window
+---@field number window
+---@field buffer Buffer
+local Window = {}
+Window.__index = Window
+
+function Window.new(winnr)
+  local bufnr = vim.api.nvim_win_get_buf(winnr)
+  local win = {
+    number = winnr,
+    buffer = buffers.get_buffer(bufnr)
+      or Buffer.new({ bufnr = bufnr, name = vim.api.nvim_buf_get_name(bufnr) }),
+  }
+  return setmetatable(win, Window)
+end
+
+function Window:close()
+  vim.api.nvim_win_close(self.number)
+end
+
+function Window:focus()
+  vim.api.nvim_set_current_win(self.number)
+end
+
+---@class TabPage
+---@field number tabpage
+---@field windows Window[]
+---@field focused Window
+local TabPage = {}
+TabPage.__index = TabPage
+
+function TabPage.new(tabnr)
+  local active_win = vim.api.nvim_tabpage_get_win(tabnr)
+  local windows = vim.api.nvim_tabpage_list_wins(tabnr)
+
+  for i, winnr in ipairs(windows) do
+    windows[i] = Window.new(winnr)
+    if winnr == active_win then
+      windows.focused = windows[i]
+    end
+  end
+
+  local tab = {
+    number = tabnr,
+    windows = windows,
+    focused = windows.focused,
+  }
+  return setmetatable(tab, TabPage)
+end
+
+function TabPage:focus()
+  vim.api.nvim_set_current_tabpage(self.number)
+end
+
+function TabPage:close()
+  for _, win in ipairs(self.windows) do
+    win:close()
+  end
+end
+
+function M.get_tabs()
+  local tabs = {}
+  local tabnrs = vim.api.nvim_list_tabpages()
+  for _, tabnr in ipairs(tabnrs) do
+    tabs[#tabs + 1] = TabPage.new(tabnr)
+    _G.cokeline.tab_lookup[tabnr] = tabs[#tabs]
+  end
+  _G.cokeline.tab_cache = tabs
+  return _G.cokeline.tab_cache
+end
+
+function M.get_tabpage(tabnr)
+  return _G.cokeline.tab_lookup[tabnr]
+end
+
+---@return Component<TabPage>[]
+function M.get_components()
+  local hovered = require("cokeline/hover").hovered()
+  local tabs = M.get_tabs()
+  for i, tab in ipairs(tabs) do
+    for _, c in ipairs(_G.cokeline.tabs) do
+      tab.is_hovered = hovered and hovered.index == c.index
+      tabs[i] = c:render(RenderContext:tab(tab))
+    end
+  end
+  return tabs
+end
+
+function M.width()
+  return components.width(M.get_components())
+end
+
+return M

--- a/lua/cokeline/tabs.lua
+++ b/lua/cokeline/tabs.lua
@@ -1,7 +1,5 @@
 local buffers = require("cokeline.buffers")
 local Buffer = buffers.Buffer
-local components = require("cokeline/components")
-local RenderContext = require("cokeline.context")
 
 local M = {}
 
@@ -22,7 +20,7 @@ function Window.new(winnr)
 end
 
 function Window:close()
-  vim.api.nvim_win_close(self.number)
+  pcall(vim.api.nvim_win_close, self.number, false)
 end
 
 function Window:focus()
@@ -103,24 +101,6 @@ end
 
 function M.get_tabpage(tabnr)
   return _G.cokeline.tab_lookup[tabnr]
-end
-
----@return Component<TabPage>[]
-function M.get_components()
-  local hovered = require("cokeline/hover").hovered()
-  local tabs = M.get_tabs()
-  local comps = {}
-  for i, tab in ipairs(tabs) do
-    for _, c in ipairs(_G.cokeline.tabs) do
-      tab.is_hovered = hovered and hovered.index == c.index
-      comps[i] = c:render(RenderContext:tab(tab))
-    end
-  end
-  return comps
-end
-
-function M.width()
-  return components.width(M.get_components())
 end
 
 return M

--- a/lua/cokeline/tabs.lua
+++ b/lua/cokeline/tabs.lua
@@ -40,17 +40,18 @@ function TabPage.new(tabnr)
   local active_win = vim.api.nvim_tabpage_get_win(tabnr)
   local windows = vim.api.nvim_tabpage_list_wins(tabnr)
 
+  local focused
   for i, winnr in ipairs(windows) do
     windows[i] = Window.new(winnr)
     if winnr == active_win then
-      windows.focused = windows[i]
+      focused = windows[i]
     end
   end
 
   local tab = {
     number = tabnr,
     windows = windows,
-    focused = windows.focused,
+    focused = focused,
   }
   return setmetatable(tab, TabPage)
 end
@@ -65,14 +66,38 @@ function TabPage:close()
   end
 end
 
-function M.get_tabs()
+function M.fetch_tabs()
   local tabs = {}
   local tabnrs = vim.api.nvim_list_tabpages()
-  for _, tabnr in ipairs(tabnrs) do
-    tabs[#tabs + 1] = TabPage.new(tabnr)
-    _G.cokeline.tab_lookup[tabnr] = tabs[#tabs]
+  table.sort(tabnrs, function(a, b)
+    return a < b
+  end)
+  for t, tabnr in ipairs(tabnrs) do
+    if _G.cokeline.tab_lookup[tabnr] ~= nil then
+      tabs[t] = _G.cokeline.tab_lookup[tabnr]
+      local windows = vim.api.nvim_tabpage_list_wins(tabnr)
+      for i, winnr in ipairs(windows) do
+        if
+          tabs[t].windows[i] == nil
+          or tabs[t].windows[i].buffer == nil
+          or tabs[t].windows[i].buffer.number
+            ~= vim.api.nvim_win_get_buf(winnr)
+        then
+          tabs[t].windows[i] = Window.new(winnr)
+        end
+      end
+    else
+      tabs[t] = TabPage.new(tabnr)
+      _G.cokeline.tab_lookup[tabnr] = tabs[t]
+    end
   end
   _G.cokeline.tab_cache = tabs
+end
+
+function M.get_tabs()
+  if not _G.cokeline.tab_cache or #_G.cokeline.tab_cache == 0 then
+    M.fetch_tabs()
+  end
   return _G.cokeline.tab_cache
 end
 
@@ -84,13 +109,14 @@ end
 function M.get_components()
   local hovered = require("cokeline/hover").hovered()
   local tabs = M.get_tabs()
+  local comps = {}
   for i, tab in ipairs(tabs) do
     for _, c in ipairs(_G.cokeline.tabs) do
       tab.is_hovered = hovered and hovered.index == c.index
-      tabs[i] = c:render(RenderContext:tab(tab))
+      comps[i] = c:render(RenderContext:tab(tab))
     end
   end
-  return tabs
+  return comps
 end
 
 function M.width()


### PR DESCRIPTION
Allows for tab components to be displayed in the tabline in addition to buffers. Tab components have the same API as buffer, sidebar and rhs components, except their methods take a TabPage object as context.

Closes #35 