### PR TITLE
feat: custom sorting functions

### DIFF
--- a/.github/workflows/lines.yaml
+++ b/.github/workflows/lines.yaml
@@ -1,5 +1,5 @@
 name: "Check line width"
-on: [ push, pull_request ]
+on: [push, pull_request]
 jobs:
   # line-number:
   #   name: Sloc < 1000
@@ -14,5 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cargo install ripgrep
+      - run: cargo install --locked ripgrep
       - run: max_line_width=$(rg --glob '*.{lua,vim}' --no-heading --no-filename --no-line-number . | awk '{print length}' | sort -n | tail -n 1); if [ ${max_line_width} -gt 79 ]; then exit 1; fi

--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -430,7 +430,9 @@ function M.get_valid_buffers()
       :tolist()
   end
 
-  if _G.cokeline.config.buffers.new_buffers_position == "last" then
+  if type(_G.cokeline.config.buffers.new_buffers_position) == "function" then
+    sort(buffers, _G.cokeline.config.buffers.new_buffers_position)
+  elseif _G.cokeline.config.buffers.new_buffers_position == "last" then
     sort(buffers, sort_by_new_after_last)
   elseif _G.cokeline.config.buffers.new_buffers_position == "next" then
     sort(buffers, sort_by_new_after_current)

--- a/lua/cokeline/config.lua
+++ b/lua/cokeline/config.lua
@@ -145,6 +145,13 @@ local get = function(preferences)
   _G.cokeline.rhs = {}
   _G.cokeline.sidebar = {}
   _G.cokeline.tabs = {}
+  if preferences.buffers and preferences.buffers.new_buffers_position then
+    if not _G.cokeline.config.buffers then
+      _G.cokeline.config.buffers = {}
+    end
+    _G.cokeline.config.buffers.new_buffers_position =
+      preferences.buffers.new_buffers_position
+  end
   local id = 1
   for _, component in ipairs(config.components) do
     local new_component = Component.new(component, id, config.default_hl)


### PR DESCRIPTION
Closes #144 

Note that this is not a final solution and ultimately I'd like to refactor the way sorting is handled so that there are different levels of sort priority that can be determined by multiple providers. That way, you could quickly create different ordering providers and for example keep harpoon marks on the left, but still be able to sort the rest of your open buffers based on some other function.

However, this was super quick to implement so can't hurt to have for now :)