### PR TITLE
feat!: support for more highlight attrs

### DIFF
--- a/lua/cokeline/hlgroups.lua
+++ b/lua/cokeline/hlgroups.lua
@@ -1,5 +1,41 @@
-local get_hex = require("cokeline.utils").get_hex
-local cmd = vim.cmd
+local M = {}
+
+---@param rgb integer
+---@return string hex
+function M.hex(rgb)
+  local band, lsr = bit.band, bit.rshift
+
+  local r = lsr(band(rgb, 0xff00000), 16)
+  local g = lsr(band(rgb, 0x00ff00), 8)
+  local b = band(rgb, 0x0000ff)
+
+  return ("#%02x%02x%02x"):format(r, g, b)
+end
+
+function M.get_hl(name)
+  local hl = vim.api.nvim_get_hl(0, { name = name })
+  if not hl then
+    return
+  end
+  if hl.fg then
+    hl.fg = M.hex(hl.fg)
+  end
+  if hl.bg then
+    hl.bg = M.hex(hl.bg)
+  end
+  if hl.sp then
+    hl.sp = M.hex(hl.sp)
+  end
+  return hl
+end
+
+function M.get_hl_attr(name, attr)
+  local hl = M.get_hl(name)
+  if not hl then
+    return
+  end
+  return hl[attr]
+end
 
 ---@class Hlgroup
 ---@field name  string
@@ -11,30 +47,40 @@ Hlgroup.__index = Hlgroup
 
 ---Sets the highlight group, then returns a new `Hlgroup` table.
 ---@param name  string
----@param gui   string
----@param guifg string
----@param guibg string
+---@param fg string
+---@param bg string | nil
+---@param sp string | nil
+---@param gui_attrs table<string, bool>
 ---@return Hlgroup
-Hlgroup.new = function(name, gui, guifg, guibg)
-  if vim.fn.hlexists(guifg) == 1 then
-    guifg = get_hex(guifg, "fg")
+Hlgroup.new = function(name, fg, bg, sp, gui_attrs)
+  local hlgroup = {}
+  if vim.fn.hlexists(fg) == 1 then
+    hlgroup.fg = M.get_hl_attr(fg, "fg")
+  else
+    hlgroup.fg = fg
   end
-  if vim.fn.hlexists(guibg) == 1 then
-    guibg = get_hex(guibg, "bg")
+  if vim.fn.hlexists(bg) == 1 then
+    hlgroup.bg = M.get_hl_attr(bg, "bg")
+  else
+    hlgroup.bg = bg
+  end
+  if sp and vim.fn.hlexists(sp) == 1 then
+    hlgroup.sp = M.get_hl_attr(sp, "sp")
+  else
+    hlgroup.sp = sp
   end
 
-  -- Clear the highlight group before (re)defining it.
-  cmd(("highlight clear %s"):format(name))
-  cmd(
-    ("highlight %s gui=%s guifg=%s guibg=%s"):format(name, gui, guifg, guibg)
-  )
+  for attr, val in pairs(gui_attrs) do
+    if type(val) == "boolean" then
+      hlgroup[attr] = val
+    elseif type(val) == "string" and vim.fn.hlexists(val) == 1 then
+      hlgroup[attr] = M.get_hl_attr(val, attr)
+    end
+  end
 
-  local hlgroup = {
-    name = name,
-    gui = gui,
-    guifg = guifg,
-    guibg = guibg,
-  }
+  vim.api.nvim_set_hl(0, name, hlgroup)
+
+  hlgroup.name = name
   setmetatable(hlgroup, Hlgroup)
   return hlgroup
 end
@@ -58,6 +104,6 @@ Hlgroup.embed = function(self, text)
   return ("%%#%s#%s%%*"):format(self.name, text)
 end
 
-return {
-  Hlgroup = Hlgroup,
-}
+M.Hlgroup = Hlgroup
+
+return M

--- a/lua/cokeline/utils.lua
+++ b/lua/cokeline/utils.lua
@@ -2,6 +2,7 @@ local vim_fn = vim.fn
 
 ---Returns the color set by the current colorscheme for the `attr` attribute of
 ---the `hlgroup_name` highlight group in hexadecimal format.
+---@deprecated
 ---@param hlgroup_name  string
 ---@param attr  '"fg"' | '"bg"'
 ---@return string


### PR DESCRIPTION
Closes #147

This is a breaking change as the config for highlighting is slightly different. Instead of using a "style" property, individual properties such as `bold` or `underline` are set via `[name] = boolean`, or `[name] = fun(cx):boolean`, the same way that `fg`, `bg`, and `sp` are set.