### PR TITLE
fixup: (3682c78e): README: Replace `focused` with `fg` in default_hl

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ local yellow = vim.g.terminal_color_3
 
 require('cokeline').setup({
   default_hl = {
-    focused = function(buffer)
+    fg = function(buffer)
       return
         buffer.is_focused
         and get_hex('Normal', 'fg')
@@ -308,7 +308,7 @@ local yellow = vim.g.terminal_color_3
 
 require('cokeline').setup({
   default_hl = {
-    focused = function(buffer)
+    fg = function(buffer)
       return
         buffer.is_focused
         and get_hex('Normal', 'fg')


### PR DESCRIPTION
commit: (3682c78e0b727c12fb84405b694c14cc1af4d64b) Removes support for
hl subtables and a single default hl table was used for buffers.

Reflect the changes inside the README configs as well.

Change-Id: I318d2c824fcd62606615910847abf1155e90440a
Signed-off-by: UtsavBalar1231 <utsavbalar1231@gmail.com>
