### PR TITLE
Reuse pick letters

### DIFF
--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -22,8 +22,6 @@ local current_valid_index
 ---@type string?
 local valid_pick_letters
 
-local first_valid = 1
-
 local taken_pick_letters = {}
 local taken_pick_indices = {}
 local buf_order = {}
@@ -106,6 +104,8 @@ end
 ---@param bufnr  bufnr
 ---@return string
 local get_pick_letter = function(filename, bufnr)
+  local first_valid = 1
+
   -- Initialize the valid letters string, if not already initialized
   if not valid_pick_letters then
     valid_pick_letters = config.pick.letters


### PR DESCRIPTION
Make `first_valid` a function-level variable rather than a module-level one.  This way when buffers are deleted, the letters at the begining of the list are re-used.

This improves the UX when `use_filename` is false:
  - The letters at the begining of the list are likely to be the best ones.  My setup puts the home row keys at the start.
  - Otherwise, if you keep deleting buffers you can use up all the letters and get `?` for all your buffers.