### PR TITLE
use nvim's internal numbering for tab index

### DIFF
--- a/lua/cokeline/tabs.lua
+++ b/lua/cokeline/tabs.lua
@@ -93,7 +93,8 @@ function M.fetch_tabs()
   table.sort(tabnrs, function(a, b)
     return a < b
   end)
-  for t, tabnr in ipairs(tabnrs) do
+  for _, tabnr in ipairs(tabnrs) do
+    local t = vim.api.nvim_tabpage_get_number(tabnr)
     if state.tab_lookup[tabnr] ~= nil then
       tabs[t] = state.tab_lookup[tabnr]
       tabs[t].is_active = tabnr == active_tab


### PR DESCRIPTION
Fixes an issue where opening new tabs from a tab other than the last one causes a mismatch between the tab index and the ordering of tab components. This gets the index from neovim's api and is the same number used by `gt` and `gT` keymaps. Not sure if this breaks anything else though.