### PR TITLE
Do not shorten components if there's nothing to shorten

### DIFF
--- a/lua/cokeline/components.lua
+++ b/lua/cokeline/components.lua
@@ -202,6 +202,8 @@ end
 ---@param direction  '"left"' | '"right"' | nil
 ---@return Component<Cx>[]
 local shorten_components = function(components, to_width, direction)
+  if #components == 0 then return components end
+
   local current_width = width_of_components(components)
 
   -- `extra` is the width of the extra characters that are appended when a


### PR DESCRIPTION
Hi

I'm not using components for buffers themselves (only for tabpages), so I set them as an empty table. But that caused crashes. So I added this one line to make sure it doesn't try to shorten components, if there are none